### PR TITLE
[add] 認証の追加, テスト用パスの追加

### DIFF
--- a/app/domain/entity/entity.go
+++ b/app/domain/entity/entity.go
@@ -5,6 +5,7 @@ import "encoding/json"
 type GetUser struct {
 	UserID   string `json:"userID"`
 	UserName string `json:"userName"`
+	Passwd   string `json:"passwd"`
 	Icon     string `json:"icon"`
 }
 

--- a/app/infra/db.go
+++ b/app/infra/db.go
@@ -16,8 +16,8 @@ import (
 var (
 	ErrFirebaseInitializaition = errors.New("failed to initialize Firebase")
 	ErrFirestoreConnection     = errors.New("failed to establish connection to Firestore")
-	ErrUserDataNotFound        = errors.New("user data not found")
-	ErrUserDataAlreadyExists   = errors.New("user data already exists")
+	ErrUserNotFound            = errors.New("user not found")
+	ErrUserAlreadyExists       = errors.New("user already exists")
 )
 
 type DBRepository struct {
@@ -67,7 +67,7 @@ func (r *DBRepository) GetUser(userID string) (*entity.GetUser, error) {
 		return nil, err
 	}
 	if !exist {
-		return nil, ErrUserDataNotFound
+		return nil, ErrUserNotFound
 	}
 
 	docSnap, err := doc.Get(r.Context)
@@ -97,7 +97,7 @@ func (r *DBRepository) InsertUser(user *entity.InsertUser) error {
 		return err
 	}
 	if exist {
-		return ErrUserDataAlreadyExists
+		return ErrUserAlreadyExists
 	}
 
 	_, err = doc.Set(r.Context, data)
@@ -113,7 +113,7 @@ func (r *DBRepository) PutUser(user *entity.PutUser) error {
 		return err
 	}
 	if !exist {
-		return ErrUserDataNotFound
+		return ErrUserNotFound
 	}
 
 	info := []firestore.Update{

--- a/app/interfaces/handler/user.go
+++ b/app/interfaces/handler/user.go
@@ -111,3 +111,35 @@ func (h *UserHandler) UpdateUser(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, response)
 }
+
+func (h *UserHandler) Login(c echo.Context) error {
+
+	var req request.LoginRequest
+
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(
+			http.StatusBadRequest,
+			response.Error{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			},
+		)
+	}
+
+	info, err := h.userUseCase.Login(&req)
+	if err != nil {
+		return c.JSON(
+			http.StatusNotFound,
+			response.Error{
+				Code:    http.StatusNotFound,
+				Message: err.Error(),
+			},
+		)
+	}
+
+	response := &response.LoginResponse{
+		Token: info.Token,
+	}
+
+	return c.JSON(http.StatusOK, response)
+}

--- a/app/interfaces/middleware/auth.go
+++ b/app/interfaces/middleware/auth.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"flyme-backend/app/packages/auth"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+func Authentication(contextKey string) echo.MiddlewareFunc {
+	return middleware.JWTWithConfig(
+		middleware.JWTConfig{
+			ContextKey: contextKey,
+			ParseTokenFunc: func(tokenStr string, c echo.Context) (interface{}, error) {
+				return auth.ValidateUserToken(tokenStr)
+			},
+		},
+	)
+}

--- a/app/interfaces/request/user.go
+++ b/app/interfaces/request/user.go
@@ -1,5 +1,10 @@
 package request
 
+type LoginRequest struct {
+	UserID string `json:"userID"`
+	Passwd string `json:"passwd"`
+}
+
 type CreateUserRequest struct {
 	UserID   string `json:"userID"`
 	UserName string `json:"userName"`

--- a/app/interfaces/response/user.go
+++ b/app/interfaces/response/user.go
@@ -17,3 +17,7 @@ type UpdateUserResponse struct {
 	UserName string `json:"userName"`
 	Icon     string `json:"icon"`
 }
+
+type LoginResponse struct {
+	Token string `json:"token"`
+}

--- a/app/interfaces/server.go
+++ b/app/interfaces/server.go
@@ -4,7 +4,9 @@ import (
 	"flyme-backend/app/config"
 	"flyme-backend/app/infra"
 	"flyme-backend/app/interfaces/handler"
+	"flyme-backend/app/interfaces/middleware"
 	"flyme-backend/app/logger"
+	"flyme-backend/app/packages/auth"
 	"flyme-backend/app/usecase"
 	"net/http"
 
@@ -38,9 +40,23 @@ func (s *Server) StartServer() {
 		return c.String(http.StatusOK, "pong")
 	})
 
+	s.Router.POST("/user", userHandler.CreateUser)
+	s.Router.POST("/login", userHandler.Login)
 	s.Router.GET("/user/:user_id", userHandler.ReadUser)
 	s.Router.PUT("/user/:user_id", userHandler.UpdateUser)
-	s.Router.POST("/user", userHandler.CreateUser)
+
+	// authorized '/ping' ---
+	r := s.Router.Group("/auth")
+	{
+		const contextKey = "user"
+		r.Use(middleware.Authentication(contextKey))
+
+		r.GET("/ping", func(c echo.Context) error {
+			ctx, _ := auth.GetUserContext(c.Get(contextKey))
+			return c.String(http.StatusOK, "pong by "+ctx.UserID)
+		})
+	}
+	// ---
 
 	if config.MODE == config.Production {
 		s.Router.HideBanner = true

--- a/app/packages/auth/auth.go
+++ b/app/packages/auth/auth.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 type UserJwtClaims struct {

--- a/app/packages/auth/auth.go
+++ b/app/packages/auth/auth.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+)
+
+type UserJwtClaims struct {
+	UserID string `json:"userID"`
+}
+
+var signingKey []byte
+
+func init() {
+	signingKey = make([]byte, 128)
+	_, err := rand.Read(signingKey)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func GenerateUserToken(userID string, passwd string) (string, error) {
+
+	token := jwt.New(jwt.SigningMethodHS256)
+
+	claims := token.Claims.(jwt.MapClaims)
+	claims["userID"] = userID
+	claims["iat"] = time.Now().Unix()
+	claims["exp"] = time.Now().Add(time.Hour * 24).Unix()
+
+	tokenStr, err := token.SignedString(signingKey)
+	if err != nil {
+		return "", err
+	}
+	return tokenStr, nil
+}
+
+func ValidateUserToken(tokenStr string) (interface{}, error) {
+
+	keyFunc := func(t *jwt.Token) (interface{}, error) {
+		if t.Method.Alg() != "HS256" {
+			return nil, errors.New("unexpected jwt signing method")
+		}
+		return signingKey, nil
+	}
+
+	token, err := jwt.Parse(tokenStr, keyFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	if !token.Valid {
+		return nil, errors.New("invalid token")
+	}
+
+	return token, nil
+}
+
+func GetUserContext(src interface{}) (*UserJwtClaims, error) {
+	if src == nil {
+		return nil, errors.New("failed to resolve user context")
+	}
+	token := src.(*jwt.Token)
+
+	jsonStr, err := json.Marshal(token.Claims)
+	if err != nil {
+		return nil, err
+	}
+
+	var claims UserJwtClaims
+	err = json.Unmarshal(jsonStr, &claims)
+	if err != nil {
+		return nil, err
+	}
+
+	return &claims, nil
+}

--- a/app/usecase/user.go
+++ b/app/usecase/user.go
@@ -1,10 +1,12 @@
 package usecase
 
 import (
+	"errors"
 	"flyme-backend/app/domain/entity"
 	"flyme-backend/app/domain/repository"
 	"flyme-backend/app/interfaces/request"
 	"flyme-backend/app/interfaces/response"
+	"flyme-backend/app/packages/auth"
 )
 
 type UserUseCase struct {
@@ -75,6 +77,29 @@ func (u *UserUseCase) UpdateUser(userID string, req *request.UpdateUserRequest) 
 		UserID:   query.UserID,
 		UserName: query.UserName,
 		Icon:     query.Icon,
+	}
+
+	return res, nil
+}
+
+func (u *UserUseCase) Login(req *request.LoginRequest) (*response.LoginResponse, error) {
+	user, err := u.dbRepository.GetUser(req.UserID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Passwd != user.Passwd {
+		return nil, errors.New("password incorrect")
+	}
+
+	token, err := auth.GenerateUserToken(req.UserID, req.Passwd)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &response.LoginResponse{
+		Token: token,
 	}
 
 	return res, nil

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/firestore v1.9.0
 	firebase.google.com/go/v4 v4.10.0
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/labstack/echo/v4 v4.9.1
 	go.uber.org/zap v1.24.0
 	google.golang.org/api v0.104.0
@@ -19,7 +20,6 @@ require (
 	cloud.google.com/go/longrunning v0.3.0 // indirect
 	cloud.google.com/go/storage v1.28.1 // indirect
 	github.com/MicahParks/keyfunc v1.7.0 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/firestore v1.9.0
 	firebase.google.com/go/v4 v4.10.0
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/labstack/echo/v4 v4.9.1
 	go.uber.org/zap v1.24.0
 	google.golang.org/api v0.104.0
@@ -20,7 +20,7 @@ require (
 	cloud.google.com/go/longrunning v0.3.0 // indirect
 	cloud.google.com/go/storage v1.28.1 // indirect
 	github.com/MicahParks/keyfunc v1.7.0 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect


### PR DESCRIPTION
`/login`のみを実装するつもりでしたが、それだとテスト面の様々な部分で都合が悪いため、認証の仕組みとテスト用のパスも同時に書くことにしました

### テストについて

```
$ curl -X 'GET' \
  'http://localhost:8080/auth/ping' \
  -H 'accept: text/plain' \
  -H 'Authorization: Bearer %/login後に受け取ったトークン%'
```
`/auth/ping` にGETすると `pong by (userID)`が返ってきます