### PR TITLE
[add] デバッグ環境用cors設定

### DIFF
--- a/app/interfaces/server.go
+++ b/app/interfaces/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 )
 
 type Server struct {
@@ -21,6 +22,13 @@ func NewServer() *Server {
 
 func (s *Server) StartServer() {
 	s.Router.Use(logger.EchoLogger())
+
+	if config.MODE == config.Developing {
+		s.Router.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+			AllowOrigins: []string{"*"},
+			AllowMethods: []string{http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete},
+		}))
+	}
 
 	dbRepository, err := infra.NewDBRepository()
 	if err != nil {


### PR DESCRIPTION
productionでないときには`access-control-allow-origin`を`*`にする